### PR TITLE
Allow custom names for modules and/or actions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ export class Module<STATETYPE, ACTIONEXTRADATA> {
   moduleID: string;
 
   constructor(options: {
+    moduleID?: string,
     initialState: STATETYPE,
     actionExtraData?: () => ACTIONEXTRADATA,
     postReducer?: (state: STATETYPE) => STATETYPE,
@@ -42,15 +43,20 @@ export class Module<STATETYPE, ACTIONEXTRADATA> {
     this.initialState = options.initialState;
     this.actionExtraData = options.actionExtraData || (() => { return {} as ACTIONEXTRADATA;});
     this.postReducer = options.postReducer || null;
+    this.moduleID = options.moduleID || null;
+
+    if (this.moduleID && typeof globalModuleIDs[this.moduleID] !== 'undefined') throw new Error(`Module name "${this.moduleID}" is not unique.`);
 
     // generate a unique id for this module.
-    this.moduleID = generateID(6);
-    let retryCount = 10;
-    while (typeof globalModuleIDs[this.moduleID] !== 'undefined' && --retryCount >= 0) {
+    if (!this.moduleID) {
       this.moduleID = generateID(6);
+      let retryCount = 10;
+      while (typeof globalModuleIDs[this.moduleID] !== 'undefined' && --retryCount >= 0) {
+        this.moduleID = generateID(6);
+      }
+      // extremely unlikely to ever happen
+      if (typeof globalModuleIDs[this.moduleID] !== 'undefined') throw new Error('failed to generate a unique module id');
     }
-    // extremely unlikely to ever happen
-    if (typeof globalModuleIDs[this.moduleID] !== 'undefined') throw new Error('failed to generate a unique module id');
     globalModuleIDs[this.moduleID] = this.moduleID;
   }
 

--- a/index.ts
+++ b/index.ts
@@ -144,6 +144,9 @@ export class Module<STATETYPE, ACTIONEXTRADATA> {
       while (typeof this.actionDefs[type] !== 'undefined' && --retry >= 0) {
         type = this.moduleID + '/' + generateID(6);
       }
+    } else if (type.indexOf('/') === 0) {
+      // When the type name starts with a "/", we assume we want to prepend the module name.
+      type = this.moduleID + type;
     }
 
     if (typeof this.actionDefs[type] !== 'undefined') throw new Error('duplicate type name provided to createAction or type name generation failed to generate a unique type name');


### PR DESCRIPTION
This is a nice utility for rapidly creating Duck-style typed redux modules in TypeScript.

However, to me it seems to be missing some user-friendliness towards debugging capabilities. E.g., the automatically generated module names are not that "nice" when using tools like [Redux DevTools](gaearon/redux-devtools).

This pull request allows you to (optionally) specify your module name.

Also, if you start your _action name_ with a slash, it will prepend your module name.


```js
const module = new Module({
  moduleID: 'lorem',
  initialState: {
    todos: Map<string, TODO>()
  },
});

export const addTodo = module.createAction({
  type: '/ipsum',
  action: (todo: string) => {
    return {
      id: 1234,
      task: todo,
    };
  },
  // ...
};
```

would generate a module with ID `lorem`, and the type for `addTodo` would be `lorem/ipsum`.  
In case the action type would be 'ipsum', the `lorem` module prefix would not have been appended.

---

Maybe it would be nicer to have some module-level (or default) configuration to automatically use this behavior. Allowing consumers of this library to opt-out?

Let me know what you think.